### PR TITLE
Wip/modularize xml parsres

### DIFF
--- a/dbuild-meta.json
+++ b/dbuild-meta.json
@@ -46,6 +46,16 @@
                     "name": "scala-reflect",
                     "organization": "org.scala-lang"
                 }
+                {
+                    "extension": "jar",
+                    "name": "scala-xml",
+                    "organization": "org.scala-lang.modules"
+                },
+                {
+                    "extension": "jar",
+                    "name": "scala-parser-combinators",
+                    "organization": "org.scala-lang.modules"
+                }
             ],
             "name": "scala-compiler",
             "organization": "org.scala-lang"
@@ -84,39 +94,6 @@
                 }
             ],
             "name": "scala-actors",
-            "organization": "org.scala-lang"
-        },
-        {
-            "artifacts": [
-                {
-                    "extension": "jar",
-                    "name": "scaladoc",
-                    "organization": "org.scala-lang"
-                }
-            ],
-            "dependencies": [
-                {
-                    "extension": "jar",
-                    "name": "scala-compiler",
-                    "organization": "org.scala-lang"
-                },
-                {
-                    "extension": "jar",
-                    "name": "scala-partest",
-                    "organization": "org.scala-lang"
-                },
-                {
-                    "extension": "jar",
-                    "name": "scala-xml",
-                    "organization": "org.scala-lang"
-                },
-                {
-                    "extension": "jar",
-                    "name": "scala-parser-combinators",
-                    "organization": "org.scala-lang"
-                }
-            ],
-            "name": "scaladoc",
             "organization": "org.scala-lang"
         },
         {

--- a/dbuild-meta.json
+++ b/dbuild-meta.json
@@ -13,6 +13,7 @@
             "dependencies": [],
             "name": "scala-library",
             "organization": "org.scala-lang"
+
         },
         {
             "artifacts": [
@@ -45,7 +46,7 @@
                     "extension": "jar",
                     "name": "scala-reflect",
                     "organization": "org.scala-lang"
-                }
+                },
                 {
                     "extension": "jar",
                     "name": "scala-xml",


### PR DESCRIPTION
Fixed dbuild metadata for modularization so dbuild can appropriately determine dependencies and ensure modules are resolved externally (or built externally).
