### PR TITLE
Don't pursue SAM translation after an arity mismatch.

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -2871,8 +2871,9 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
        *
        * Note that the arity of the sam must correspond to the arity of the function.
        */
+      val samViable = sam.exists && sameLength(sam.info.params, fun.vparams)
       val (argpts, respt) =
-        if (sam.exists && sameLength(sam.info.params, fun.vparams)) {
+        if (samViable) {
           val samInfo = pt memberInfo sam
           (samInfo.paramTypes, samInfo.resultType)
         } else {
@@ -2926,7 +2927,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
 
           // Use synthesizeSAMFunction to expand `(p1: T1, ..., pN: TN) => body`
           // to an instance of the corresponding anonymous subclass of `pt`.
-          case _ if sam.exists =>
+          case _ if samViable =>
             newTyper(context.outer).synthesizeSAMFunction(sam, fun, respt, pt, mode)
 
           // regular Function

--- a/test/files/neg/sammy_wrong_arity.check
+++ b/test/files/neg/sammy_wrong_arity.check
@@ -1,0 +1,52 @@
+sammy_wrong_arity.scala:6: error: type mismatch;
+ found   : () => Int
+ required: T1
+  (() => 0): T1
+      ^
+sammy_wrong_arity.scala:7: error: type mismatch;
+ found   : Any => Int
+ required: T2
+  ((x: Any) => 0): T2
+            ^
+sammy_wrong_arity.scala:9: error: type mismatch;
+ found   : Any => Int
+ required: T0
+  ((x: Any) => 0): T0
+            ^
+sammy_wrong_arity.scala:10: error: type mismatch;
+ found   : Any => Int
+ required: T2
+  ((x: Any) => 0): T2
+            ^
+sammy_wrong_arity.scala:12: error: type mismatch;
+ found   : (Any, Any) => Int
+ required: T0
+  ((x: Any, y: Any) => 0): T0
+                    ^
+sammy_wrong_arity.scala:13: error: type mismatch;
+ found   : (Any, Any) => Int
+ required: T1
+  ((x: Any, y: Any) => 0): T1
+                    ^
+sammy_wrong_arity.scala:15: error: missing parameter type
+  ((x) => 0): T2
+    ^
+sammy_wrong_arity.scala:17: error: missing parameter type
+  ((x) => 0): T0
+    ^
+sammy_wrong_arity.scala:18: error: missing parameter type
+  ((x) => 0): T2
+    ^
+sammy_wrong_arity.scala:20: error: missing parameter type
+  ((x, y) => 0): T0
+    ^
+sammy_wrong_arity.scala:20: error: missing parameter type
+  ((x, y) => 0): T0
+       ^
+sammy_wrong_arity.scala:21: error: missing parameter type
+  ((x, y) => 0): T1
+    ^
+sammy_wrong_arity.scala:21: error: missing parameter type
+  ((x, y) => 0): T1
+       ^
+13 errors found

--- a/test/files/neg/sammy_wrong_arity.flags
+++ b/test/files/neg/sammy_wrong_arity.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/neg/sammy_wrong_arity.scala
+++ b/test/files/neg/sammy_wrong_arity.scala
@@ -1,0 +1,22 @@
+trait T0 { def ap(): Int }
+trait T1 { def ap(a: Any): Int }
+trait T2 { def ap(a: Any, b: Any): Int }
+
+class Test {
+  (() => 0): T1
+  ((x: Any) => 0): T2
+
+  ((x: Any) => 0): T0
+  ((x: Any) => 0): T2
+
+  ((x: Any, y: Any) => 0): T0
+  ((x: Any, y: Any) => 0): T1
+
+  ((x) => 0): T2
+
+  ((x) => 0): T0
+  ((x) => 0): T2
+
+  ((x, y) => 0): T0
+  ((x, y) => 0): T1
+}


### PR DESCRIPTION
Before this change:

```
scala> trait T { def apply(a: Int): Int }
defined trait T

scala> ((x: Int, y: Int) => 0): T
<console>:9: error: object creation impossible, since method apply in trait T of type (a: Int)Int is not defined
              ((x: Int, y: Int) => 0): T
                                ^
```

After the change, these cases report the same errors as they do
_without_ -Xexperimental.
