### PR TITLE
Test cases for SAM restrictions.

### DIFF
--- a/test/files/neg/sammy_restrictions.check
+++ b/test/files/neg/sammy_restrictions.check
@@ -1,0 +1,49 @@
+sammy_restrictions.scala:31: error: type mismatch;
+ found   : () => Int
+ required: NoAbstract
+  (() => 0)      : NoAbstract
+      ^
+sammy_restrictions.scala:32: error: type mismatch;
+ found   : Int => Int
+ required: TwoAbstract
+  ((x: Int) => 0): TwoAbstract
+            ^
+sammy_restrictions.scala:34: error: class type required but DerivedOneAbstract with OneAbstract found
+  ((x: Int) => 0): NonClassType                 // "class type required". I think we should avoid SAM translation here.
+            ^
+sammy_restrictions.scala:35: error: type mismatch;
+ found   : Int => Int
+ required: NoEmptyConstructor
+  ((x: Int) => 0): NoEmptyConstructor
+            ^
+sammy_restrictions.scala:37: error: type mismatch;
+ found   : Int => Int
+ required: OneEmptySecondaryConstructor
+  ((x: Int) => 0): OneEmptySecondaryConstructor // derived class must have an empty *primary* to call.
+            ^
+sammy_restrictions.scala:38: error: type mismatch;
+ found   : Int => Int
+ required: MultipleConstructorLists
+  ((x: Int) => 0): MultipleConstructorLists
+            ^
+sammy_restrictions.scala:39: error: type mismatch;
+ found   : Int => Int
+ required: MultipleMethodLists
+  ((x: Int) => 0): MultipleMethodLists
+            ^
+sammy_restrictions.scala:40: error: type mismatch;
+ found   : Int => Int
+ required: ImplicitConstructorParam
+  ((x: Int) => 0): ImplicitConstructorParam
+            ^
+sammy_restrictions.scala:41: error: type mismatch;
+ found   : Int => Int
+ required: ImplicitMethodParam
+  ((x: Int) => 0): ImplicitMethodParam
+            ^
+sammy_restrictions.scala:44: error: type mismatch;
+ found   : Int => Int
+ required: PolyMethod
+  ((x: Int) => 0): PolyMethod
+            ^
+10 errors found

--- a/test/files/neg/sammy_restrictions.flags
+++ b/test/files/neg/sammy_restrictions.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/neg/sammy_restrictions.scala
+++ b/test/files/neg/sammy_restrictions.scala
@@ -1,0 +1,45 @@
+class NoAbstract
+
+class TwoAbstract { def ap(a: Int): Int; def pa(a: Int): Int }
+
+class Base // check that the super class constructor isn't considered.
+class NoEmptyConstructor(a: Int) extends Base { def this(a: String) = this(0); def ap(a: Int): Int }
+
+class OneEmptyConstructor() { def this(a: Int) = this(); def ap(a: Int): Int }
+
+class OneEmptySecondaryConstructor(a: Int) { def this() = this(0); def ap(a: Int): Int }
+
+class MultipleConstructorLists()() { def ap(a: Int): Int }
+
+class MultipleMethodLists()() { def ap(a: Int)(): Int }
+
+class ImplicitConstructorParam()(implicit a: String) { def ap(a: Int): Int }
+
+class ImplicitMethodParam() { def ap(a: Int)(implicit b: String): Int }
+
+class PolyClass[T] { def ap(a: T): T }
+
+class PolyMethod { def ap[T](a: T): T }
+
+class OneAbstract { def ap(a: Any): Any }
+class DerivedOneAbstract extends OneAbstract
+
+object Test {
+  implicit val s: String = ""
+  type NonClassType = DerivedOneAbstract with OneAbstract
+
+  (() => 0)      : NoAbstract
+  ((x: Int) => 0): TwoAbstract
+  ((x: Int) => 0): DerivedOneAbstract           // okay
+  ((x: Int) => 0): NonClassType                 // "class type required". I think we should avoid SAM translation here.
+  ((x: Int) => 0): NoEmptyConstructor
+  ((x: Int) => 0): OneEmptyConstructor          // okay
+  ((x: Int) => 0): OneEmptySecondaryConstructor // derived class must have an empty *primary* to call.
+  ((x: Int) => 0): MultipleConstructorLists
+  ((x: Int) => 0): MultipleMethodLists
+  ((x: Int) => 0): ImplicitConstructorParam
+  ((x: Int) => 0): ImplicitMethodParam
+
+  ((x: Int) => 0): PolyClass[Int]               // okay
+  ((x: Int) => 0): PolyMethod
+}


### PR DESCRIPTION
Only one seems to indicate something new:

  ((x: Int) => 0): NonClassType

I believe that we shouldn't pursue SAM translation for that case,
and fallthrough to Function1. That would allow for an implicit view
to finish the job.
