### PR TITLE
SIP-23 Account for literal types in varargs translation

### DIFF
--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -322,7 +322,7 @@ abstract class UnCurry extends InfoTransform
         args.take(formals.length - 1) :+ (suffix setType formals.last)
       }
 
-      val args1 = if (isVarArgTypes(formals)) transformVarargs(formals.last.typeArgs.head) else args
+      val args1 = if (isVarArgTypes(formals)) transformVarargs(formals.last.typeArgs.head.widen) else args
 
       map2(formals, args1) { (formal, arg) =>
         if (!isByNameParamType(formal))

--- a/test/files/run/literal-type-varargs.flags
+++ b/test/files/run/literal-type-varargs.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/literal-type-varargs.scala
+++ b/test/files/run/literal-type-varargs.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+   val x = List.apply[1](1)
+   assert(x == List(1))
+}


### PR DESCRIPTION
Before:

```
sandbox/test.scala:2: error: type mismatch;
 found   : Array[1]
 required: Array[Int]
```
