### PR TITLE
SIP-23 WIP

### DIFF
--- a/bincompat-backward.whitelist.conf
+++ b/bincompat-backward.whitelist.conf
@@ -208,6 +208,10 @@ filter {
     {
         matchName="scala.reflect.io.ZipArchive.scala$reflect$io$ZipArchive$$walkIterator"
         problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Types.LiteralType"
+        problemName=MissingMethodProblem
     }
   ]
 }

--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -319,6 +319,18 @@ filter {
     {
         matchName="scala.util.Random.scala$util$Random$$nextAlphaNum$1"
         problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Types$LiteralTypeApi"
+        problemName=MissingClassProblem
+    },
+    {
+        matchName="scala.reflect.api.Types.LiteralType"
+        problemName=MissingMethodProblem
+    },
+    {
+        matchName="scala.reflect.api.Types$LiteralTypeExtractor"
+        problemName=MissingClassProblem
     }
   ]
 }

--- a/spec/03-types.md
+++ b/spec/03-types.md
@@ -23,6 +23,7 @@ chapter: 3
                       |  SimpleType ‘#’ id
                       |  StableId
                       |  Path ‘.’ ‘type’
+                      |  Literal
                       |  ‘(’ Types ‘)’
   TypeArgs          ::=  ‘[’ Types ‘]’
   Types             ::=  Type {‘,’ Type}
@@ -102,16 +103,40 @@ forms.
 ### Singleton Types
 
 ```ebnf
-SimpleType  ::=  Path ‘.’ type
+SimpleType  ::=  Path ‘.’ ‘type’
 ```
 
 A singleton type is of the form $p.$`type`, where $p$ is a
 path pointing to a value expected to [conform](06-expressions.html#expression-typing)
 to `scala.AnyRef`. The type denotes the set of values
-consisting of `null` and the value denoted by $p$.
+consisting of `null` and the value denoted by $p$
+(i.e., the value $v$ for which `v eq p`).
 
-A _stable type_ is either a singleton type or a type which is
-declared to be a subtype of trait `scala.Singleton`.
+<!-- a pattern match/type test against a singleton type `p.type` desugars to `_ eq p` -->
+
+### Literal Types
+
+```ebnf
+SimpleType  ::=  Literal
+```
+
+A literal type `lit` is a special kind of singleton type which denotes the single literal value `lit`.
+Thus, the type ascription `1: 1` gives the most precise type to the literal value `1`:  the literal type `1`.
+
+At run time, an expression `e` is considered to have literal type `lit` if `e == lit`.
+Concretely, the result of `e.isInstanceOf[lit]` and `e match { case _ : lit => }` is determined by evaluating `e == lit`.
+
+<!-- TODO: use eq when we lift it up to Any -->
+
+<!-- TODO: relate to constant types, which trigger constant folding
+  ConstantType(1).deconst =:= LiteralType(1)
+  LiteralType(1).widen =:= IntClass.tpe
+-->
+
+
+### Stable Types
+A _stable type_ is a singleton type, a literal type,
+or a type that is declared to be a subtype of trait `scala.Singleton`.
 
 ### Type Projection
 

--- a/spec/06-expressions.md
+++ b/spec/06-expressions.md
@@ -76,8 +76,8 @@ $T$ forSome { type $t_1[\mathit{tps}\_1] >: L_1 <: U_1$; $\ldots$; type $t_n[\ma
 SimpleExpr    ::=  Literal
 ```
 
-Typing of literals is as described [here](01-lexical-syntax.html#literals); their
-evaluation is immediate.
+Typing of literals is described along with their [lexical syntax](01-lexical-syntax.html#literals);
+their evaluation is immediate.
 
 ## The _Null_ Value
 

--- a/spec/08-pattern-matching.md
+++ b/spec/08-pattern-matching.md
@@ -337,9 +337,11 @@ A type pattern $T$ is of one of the following  forms:
   be used as type patterns, because they would match nothing in any case.
 
 * A singleton type `$p$.type`. This type pattern matches only the value
-  denoted by the path $p$ (that is, a pattern match involved a
-  comparison of the matched value with $p$ using method `eq` in class
-  `AnyRef`).
+  denoted by the path $p$ (the `eq` method is used to compare the matched value to $p$).
+
+* A literal type `$lit$`. This type pattern matches only the value
+  denoted by the literal $lit$ (the `==` method is used to compare the matched value to $lit$). <!-- SIP-23 -->
+
 * A compound type pattern `$T_1$ with $\ldots$ with $T_n$` where each $T_i$ is a
   type pattern. This type pattern matches all values that are matched by each of
   the type patterns $T_i$.

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -85,7 +85,7 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
   override def settings = currentSettings
 
   // TODO: introduce a real -Xsip:NNN flag
-  override def sip23: Boolean = settings.Xexperimental.value
+  override def sip23: Boolean = true // settings.Xexperimental.value
 
   /** Switch to turn on detailed type logs */
   var printTypings = settings.Ytyperdebug.value

--- a/src/compiler/scala/tools/nsc/Global.scala
+++ b/src/compiler/scala/tools/nsc/Global.scala
@@ -84,6 +84,9 @@ class Global(var currentSettings: Settings, var reporter: Reporter)
 
   override def settings = currentSettings
 
+  // TODO: introduce a real -Xsip:NNN flag
+  override def sip23: Boolean = settings.Xexperimental.value
+
   /** Switch to turn on detailed type logs */
   var printTypings = settings.Ytyperdebug.value
 

--- a/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
+++ b/src/compiler/scala/tools/nsc/ast/parser/Parsers.scala
@@ -339,6 +339,7 @@ self =>
     }
     private def inScalaRootPackage = inScalaPackage && currentPackage == "scala"
 
+
     def parseStartRule: () => Tree
 
     def parseRule[T](rule: this.type => T): T = {
@@ -674,11 +675,11 @@ self =>
 
     def isExprIntro: Boolean = isExprIntroToken(in.token)
 
-    def isTypeIntroToken(token: Token): Boolean = token match {
+    def isTypeIntroToken(token: Token): Boolean = (sip23 && isLiteralToken(token)) || (token match {
       case IDENTIFIER | BACKQUOTED_IDENT | THIS |
            SUPER | USCORE | LPAREN | AT => true
       case _ => false
-    }
+    })
 
     def isStatSeqEnd = in.token == RBRACE || in.token == EOF
 
@@ -930,6 +931,7 @@ self =>
        *                     |  SimpleType `#' Id
        *                     |  StableId
        *                     |  Path `.' type
+       *                     |  Literal
        *                     |  `(' Types `)'
        *                     |  WildcardType
        *  }}}
@@ -939,7 +941,8 @@ self =>
         simpleTypeRest(in.token match {
           case LPAREN   => atPos(start)(makeTupleType(inParens(types())))
           case USCORE   => wildcardType(in.skipToken())
-          case _        =>
+          case tok if sip23 && isLiteralToken(tok) => atPos(start){SingletonTypeTree(literal())} // SIP-23
+          case _ =>
             path(thisOK = false, typeOK = true) match {
               case r @ SingletonTypeTree(_) => r
               case r => convertToTypeId(r)
@@ -1020,7 +1023,15 @@ self =>
           else
             mkOp(infixType(InfixMode.RightOp))
         }
+        // SIP-23
+        def isNegatedLiteralType = sip23 && (
+          t match { // the token for `t` (Ident("-")) has already been read, thus `isLiteral` below is looking at next token (must be a literal)
+            case Ident(name) if isLiteral => name == nme.MINUS.toTypeName // TODO: OPT? lift out nme.MINUS.toTypeName?
+            case _ => false
+          }
+        )
         if (isIdent) checkRepeatedParam orElse asInfix
+        else if (isNegatedLiteralType) atPos(t.pos.start){SingletonTypeTree(literal(isNegated = true, start = t.pos.start))}
         else t
       }
 

--- a/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
+++ b/src/compiler/scala/tools/nsc/backend/icode/TypeKinds.scala
@@ -383,6 +383,7 @@ trait TypeKinds { self: ICodes =>
     case ThisType(ArrayClass)            => ObjectReference
     case ThisType(sym)                   => REFERENCE(sym)
     case SingleType(_, sym)              => primitiveOrRefType(sym)
+    case LiteralType(_)                  => toTypeKind(t.underlying)
     case ConstantType(_)                 => toTypeKind(t.underlying)
     case TypeRef(_, sym, args)           => primitiveOrClassType(sym, args)
     case ClassInfoType(_, _, ArrayClass) => abort("ClassInfoType to ArrayClass!")

--- a/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
+++ b/src/compiler/scala/tools/nsc/backend/jvm/BTypesFromSymbols.scala
@@ -207,6 +207,7 @@ class BTypesFromSymbols[G <: Global](val global: G) extends BTypes {
           case ThisType(sym)                      => classBTypeFromSymbol(sym)
           case SingleType(_, sym)                 => primitiveOrClassToBType(sym)
           case ConstantType(_)                    => typeToBType(t.underlying)
+          case LiteralType(_)                     => typeToBType(t.underlying)
           case RefinedType(parents, _)            => parents.map(typeToBType(_).asClassBType).reduceLeft((a, b) => a.jvmWiseLUB(b).get)
         }
     }

--- a/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
+++ b/src/compiler/scala/tools/nsc/symtab/classfile/Pickler.scala
@@ -223,6 +223,8 @@ abstract class Pickler extends SubComponent {
         case SingleType(pre, sym) =>
           putType(pre)
           putSymbol(sym)
+        case LiteralType(value) =>
+          putConstant(value)
         case SuperType(thistpe, supertpe) =>
           putType(thistpe)
           putType(supertpe)
@@ -452,6 +454,7 @@ abstract class Pickler extends SubComponent {
         case NoType | NoPrefix                   =>
         case ThisType(sym)                       => writeRef(sym)
         case SingleType(pre, sym)                => writeRef(pre) ; writeRef(sym)
+        case LiteralType(value)                  => writeRef(value)
         case SuperType(thistpe, supertpe)        => writeRef(thistpe) ; writeRef(supertpe)
         case ConstantType(value)                 => writeRef(value)
         case TypeBounds(lo, hi)                  => writeRef(lo) ; writeRef(hi)

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -869,6 +869,18 @@ abstract class Erasure extends AddInterfaces
      *   - Reset all other type attributes to null, thus enforcing a retyping.
      */
     private val preTransformer = new TypingTransformer(unit) {
+      // TODO: since the spec defines instanceOf checks in terms of pattern matching,
+      // this extractor should share code with TypeTestTreeMaker
+      object SingletonInstanceCheck {
+        def unapply(pt: Type): Option[(TermSymbol, Tree)] = pt match {
+          case SingleType(_, _) | LiteralType(_) | ThisType(_) | SuperType(_, _) =>
+            val cmpOp  = if (pt <:< AnyValTpe) Any_equals else Object_eq
+            val cmpArg = gen.mkAttributedQualifier(pt)
+            Some((cmpOp, cmpArg))
+          case _ =>
+            None
+        }
+      }
 
       private def preEraseNormalApply(tree: Apply) = {
         val fn = tree.fun
@@ -878,19 +890,36 @@ abstract class Erasure extends AddInterfaces
           case Select(qual, _) => qual
           case TypeApply(Select(qual, _), _) => qual
         }
+
+        // TODO SPEC: this should share logic with TypeTestTreeMaker in the pattern matcher,
+        // since `x.asInstanceOf[T]` is specified as the pattern match
+        // `x match { case x: T => x  case null => null  case _ => throw new ClassCastException }` (why is the null case needed?)
         def preEraseAsInstanceOf = {
           (fn: @unchecked) match {
             case TypeApply(Select(qual, _), List(targ)) =>
-              if (qual.tpe <:< targ.tpe)
-                atPos(tree.pos) { Typed(qual, TypeTree(targ.tpe)) }
-              else if (isNumericValueClass(qual.tpe.typeSymbol) && isNumericValueClass(targ.tpe.typeSymbol))
-                atPos(tree.pos)(numericConversion(qual, targ.tpe.typeSymbol))
-              else
-                tree
+              targ.tpe match {
+                case argTp@SingletonInstanceCheck(cmpOp, cmpArg) if sip23 => // compiler has an unsound asInstanceOf[global.type]...
+                  atPos(tree.pos) {
+                    gen.evalOnce(qual, currentOwner, currentUnit) { qual =>
+                      If(Apply(Select(qual(), cmpOp), List(cmpArg)),
+                         Typed(qual(), TypeTree(argTp)),
+                         Throw(ClassCastExceptionClass.tpe_*))
+                    }
+                  }
+                case argTp if qual.tpe <:< argTp =>
+                  atPos(tree.pos) { Typed(qual, TypeTree(argTp)) }
+                case argTp if isNumericValueClass(qual.tpe.typeSymbol) && isNumericValueClass(argTp.typeSymbol) =>
+                  atPos(tree.pos)(numericConversion(qual, argTp.typeSymbol))
+                case _ =>
+                  tree
+              }
           }
           // todo: also handle the case where the singleton type is buried in a compound
         }
 
+        // TODO SPEC: this should share logic with TypeTestTreeMaker in the pattern matcher,
+        // since `x.isInstanceOf[T]` is specified as the pattern match
+        // `x match { case _: T => true case _ => false }` (modulo numeric conversion)
         def preEraseIsInstanceOf = {
           fn match {
             case TypeApply(sel @ Select(qual, name), List(targ)) =>
@@ -904,11 +933,8 @@ abstract class Erasure extends AddInterfaces
                     List(TypeTree(tp) setPos targ.pos)) setPos fn.pos,
                   List()) setPos tree.pos
               targ.tpe match {
-                case SingleType(_, _) | LiteralType(_) | ThisType(_) | SuperType(_, _) =>
-                  val cmpOp = if (targ.tpe <:< AnyValTpe) Any_equals else Object_eq
-                  atPos(tree.pos) {
-                    Apply(Select(qual, cmpOp), List(gen.mkAttributedQualifier(targ.tpe)))
-                  }
+                case SingletonInstanceCheck(cmpOp, cmpArg) =>
+                  atPos(tree.pos) { Apply(Select(qual, cmpOp), List(cmpArg)) }
                 case RefinedType(parents, decls) if (parents.length >= 2) =>
                   gen.evalOnce(qual, currentOwner, unit) { q =>
                     // Optimization: don't generate isInstanceOf tests if the static type

--- a/src/compiler/scala/tools/nsc/transform/Erasure.scala
+++ b/src/compiler/scala/tools/nsc/transform/Erasure.scala
@@ -904,7 +904,7 @@ abstract class Erasure extends AddInterfaces
                     List(TypeTree(tp) setPos targ.pos)) setPos fn.pos,
                   List()) setPos tree.pos
               targ.tpe match {
-                case SingleType(_, _) | ThisType(_) | SuperType(_, _) =>
+                case SingleType(_, _) | LiteralType(_) | ThisType(_) | SuperType(_, _) =>
                   val cmpOp = if (targ.tpe <:< AnyValTpe) Any_equals else Object_eq
                   atPos(tree.pos) {
                     Apply(Select(qual, cmpOp), List(gen.mkAttributedQualifier(targ.tpe)))

--- a/src/compiler/scala/tools/nsc/transform/UnCurry.scala
+++ b/src/compiler/scala/tools/nsc/transform/UnCurry.scala
@@ -326,7 +326,7 @@ abstract class UnCurry extends InfoTransform
         args.take(formals.length - 1) :+ (suffix setType formals.last)
       }
 
-      val args1 = if (isVarArgTypes(formals)) transformVarargs(formals.last.typeArgs.head) else args
+      val args1 = if (isVarArgTypes(formals)) transformVarargs(formals.last.typeArgs.head.widen) else args
 
       map2(formals, args1) { (formal, arg) =>
         if (!isByNameParamType(formal))

--- a/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
+++ b/src/compiler/scala/tools/nsc/transform/patmat/MatchTreeMaking.scala
@@ -458,7 +458,16 @@ trait MatchTreeMaking extends MatchCodeGen with Debugging {
         //  - Scala's arrays are invariant (so we don't drop type tests unsoundly)
         if (extractorArgTypeTest) mkDefault
         else expectedTp match {
-          case SingleType(_, sym)                       => mkEqTest(gen.mkAttributedQualifier(expectedTp)) // SI-4577, SI-4897
+          case SingleType(_, sym)                       =>
+            val expected = gen.mkAttributedQualifier(expectedTp)
+            if (expectedTp <:< AnyRefTpe) mkEqTest(expected) // SI-4577, SI-4897
+            else mkEqualsTest(expected)
+          // TODO SIP-23: should we test equality for literal types with eq?
+          // Conceptually cleaner, as SingleType is tested using eq.
+          // In practice it doesn't really matter, since `equals` does the same thing as `eq` in the `AnyVal` subclasses of `Any`.
+          // Should revisit if we end up lifting `eq`'s definition to `Any`, as discussed here:
+          // https://groups.google.com/d/msg/scala-internals/jsVlJI4H5OQ/8emZWRmgzcoJ
+          case LiteralType(const)                       => mkEqualsTest(expTp(Literal(const)))
           case ThisType(sym) if sym.isModule            => and(mkEqualsTest(CODE.REF(sym)), mkTypeTest) // must use == to support e.g. List() == Nil
           case ConstantType(Constant(null)) if isAnyRef => mkEqTest(expTp(CODE.NULL))
           case ConstantType(const)                      => mkEqualsTest(expTp(Literal(const)))

--- a/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Implicits.scala
@@ -1160,6 +1160,7 @@ trait Implicits {
           // necessary only to compile typetags used inside the Universe cake
           case ThisType(thisSym) =>
             gen.mkAttributedThis(thisSym)
+          // TODO SIP-23: TypeTag for LiteralType
           case _ =>
             // if `pre` is not a PDT, e.g. if someone wrote
             //   implicitly[scala.reflect.macros.blackbox.Context#TypeTag[Int]]

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -871,7 +871,8 @@ trait Namers extends MethodSynthesis {
     private def widenIfNecessary(sym: Symbol, tpe: Type, pt: Type): Type = {
       // Are we inferring the result type of a stable symbol, whose type doesn't refer to a hidden symbol?
       // If we refer to an inaccessible symbol, let's hope widening will result in an expressible type.
-      val mayKeepSingletonType = sym.isStable && !refersToSymbolLessAccessibleThan(tpe, sym)
+      // (A LiteralType should be widened because it's too precise for a definition's type.)
+      val mayKeepSingletonType = !tpe.isInstanceOf[LiteralType] && sym.isStable && !refersToSymbolLessAccessibleThan(tpe, sym)
 
       // Only final vals may be constant folded, so deconst inferred type of other members.
       @inline def keepSingleton = if (sym.isFinal) tpe else tpe.deconst

--- a/src/compiler/scala/tools/nsc/typechecker/Namers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Namers.scala
@@ -828,48 +828,61 @@ trait Namers extends MethodSynthesis {
       }
     }
 
-    /** This method has a big impact on the eventual compiled code.
+    private def refersToSymbolLessAccessibleThan(tp: Type, sym: Symbol): Boolean = {
+      val accessibilityReference =
+        if (sym.isValue && sym.owner.isClass && sym.isPrivate)
+          sym.getterIn(sym.owner)
+        else sym
+
+      @tailrec def loop(tp: Type): Boolean = tp match {
+        case SingleType(pre, sym) =>
+          (sym isLessAccessibleThan accessibilityReference) || loop(pre)
+        case ThisType(sym) =>
+          sym isLessAccessibleThan accessibilityReference
+        case p: SimpleTypeProxy =>
+          loop(p.underlying)
+        case _ =>
+          false
+      }
+
+      loop(tp)
+    }
+
+    /**
+     * This method has a big impact on the eventual compiled code.
      *  At this point many values have the most specific possible
      *  type (e.g. in val x = 42, x's type is Int(42), not Int) but
-     *  most need to be widened to avoid undesirable propagation of
+     *  most need to be widened (which deconsts) to avoid undesirable propagation of
      *  those singleton types.
      *
      *  However, the compilation of pattern matches into switch
      *  statements depends on constant folding, which will only take
-     *  place for those values which aren't widened.  The "final"
+     *  place for those values which aren't deconsted.  The "final"
      *  modifier is the present means of signaling that a constant
-     *  value should not be widened, so it has a use even in situations
+     *  value should not deconsted, so it has a use even in situations
      *  whether it is otherwise redundant (such as in a singleton.)
+     *
+     *  TODO: spec -- this is a crucial part of type inference
+     *
+     *  NOTES:
+     *   - Can we keep more singleton types? (E.g., for local definitions.)
+     *   - Do we need to check tpe.deconst <:< pt? (Probably not, since ConstantTypes are not user-expressible.)
      */
     private def widenIfNecessary(sym: Symbol, tpe: Type, pt: Type): Type = {
-      val getter =
-        if (sym.isValue && sym.owner.isClass && sym.isPrivate)
-          sym.getter(sym.owner)
-        else sym
-      def isHidden(tp: Type): Boolean = tp match {
-        case SingleType(pre, sym) =>
-          (sym isLessAccessibleThan getter) || isHidden(pre)
-        case ThisType(sym) =>
-          sym isLessAccessibleThan getter
-        case p: SimpleTypeProxy =>
-          isHidden(p.underlying)
-        case _ =>
-          false
-      }
-      val shouldWiden = (
-           !tpe.typeSymbolDirect.isModuleClass // Infer Foo.type instead of "object Foo"
-        && (tpe.widen <:< pt)                  // Don't widen our way out of conforming to pt
-        && (   sym.isVariable
-            || sym.isMethod && !sym.hasAccessorFlag
-            || isHidden(tpe)
-           )
-      )
-      dropIllegalStarTypes(
-        if (shouldWiden) tpe.widen
-        else if (sym.isFinal) tpe    // "final val" allowed to retain constant type
-        else tpe.deconst
-      )
+      // Are we inferring the result type of a stable symbol, whose type doesn't refer to a hidden symbol?
+      // If we refer to an inaccessible symbol, let's hope widening will result in an expressible type.
+      val mayKeepSingletonType = sym.isStable && !refersToSymbolLessAccessibleThan(tpe, sym)
+
+      // Only final vals may be constant folded, so deconst inferred type of other members.
+      @inline def keepSingleton = if (sym.isFinal) tpe else tpe.deconst
+
+      // Only widen if the definition can't keep its inferred singleton type,
+      // (Also keep singleton type if so indicated by the expected type `pt`
+      //  OPT: 99.99% of the time, `pt` will be `WildcardType`).
+      if (mayKeepSingletonType || ((pt ne WildcardType) && !(tpe.widen <:< pt))) keepSingleton
+      else tpe.widen
     }
+
     /** Computes the type of the body in a ValDef or DefDef, and
      *  assigns the type to the tpt's node.  Returns the type.
      */
@@ -879,7 +892,7 @@ trait Namers extends MethodSynthesis {
         case _ => defnTyper.computeType(tree.rhs, pt)
       }
 
-      val defnTpe = widenIfNecessary(tree.symbol, rhsTpe, pt)
+      val defnTpe = dropIllegalStarTypes(widenIfNecessary(tree.symbol, rhsTpe, pt))
       tree.tpt defineType defnTpe setPos tree.pos.focus
       tree.tpt.tpe
     }

--- a/src/reflect/scala/reflect/api/Types.scala
+++ b/src/reflect/scala/reflect/api/Types.scala
@@ -528,12 +528,17 @@ trait Types {
      */
     def supertpe: Type
   }
-  /** The `ConstantType` type is not directly written in user programs, but arises as the type of a constant.
-   *  The REPL expresses constant types like `Int(11)`. Here are some constants with their types:
+
+  /** A `ConstantType` type cannot be expressed in user programs; it is inferred as the type of a constant.
+   *  Here are some constants with their types and the internal string representation:
    *  {{{
-   *     1           ConstantType(Constant(1))
-   *     "abc"       ConstantType(Constant("abc"))
+   *     1           ConstantType(Constant(1))       Int(1)
+   *     "abc"       ConstantType(Constant("abc"))   String("abc")
    *  }}}
+   *
+   *  ConstantTypes denote values that may safely be constant folded during type checking.
+   *  The `deconst` operation returns the equivalent type that will not be constant folded.
+   *
    *  @template
    *  @group Types
    */
@@ -561,6 +566,36 @@ trait Types {
    *  @group API
    */
   trait ConstantTypeApi extends TypeApi { this: ConstantType =>
+    /** The compile-time constant underlying this type. */
+    def value: Constant
+  }
+
+  /** The `LiteralType` type represent a singleton type with a literal for its path.
+   *  Examples: "a".type or 42.type, which may be abbreviated to "a" or 42.
+   *
+   *  @template
+   *  @group Types
+   */
+  type LiteralType >: Null <: LiteralTypeApi with SingletonType
+
+  /** The constructor/extractor for `ConstantType` instances.
+   *  @group Extractors
+   */
+  val LiteralType: LiteralTypeExtractor
+
+  /** An extractor class to create and pattern match with syntax `LiteralType(constant)`
+   *  Here, `constant` is the constant value represented by the type.
+   *  @group Extractors
+   */
+  abstract class LiteralTypeExtractor {
+    def unapply(tpe: LiteralType): Option[Constant]
+  }
+
+  /** The API that all literal types support.
+   *  The main source of information about types is the [[scala.reflect.api.Types]] page.
+   *  @group API
+   */
+  trait LiteralTypeApi extends TypeApi { this: LiteralType =>
     /** The compile-time constant underlying this type. */
     def value: Constant
   }

--- a/src/reflect/scala/reflect/internal/Constants.scala
+++ b/src/reflect/scala/reflect/internal/Constants.scala
@@ -60,6 +60,7 @@ trait Constants extends api.Constants {
     def isFloatRange: Boolean = ByteTag <= tag && tag <= FloatTag
     def isNumeric: Boolean    = ByteTag <= tag && tag <= DoubleTag
     def isNonUnitAnyVal       = BooleanTag <= tag && tag <= DoubleTag
+    def isSuitableLiteralType = BooleanTag <= tag && tag <= NullTag
     def isAnyVal              = UnitTag <= tag && tag <= DoubleTag
 
     def tpe: Type = tag match {

--- a/src/reflect/scala/reflect/internal/Definitions.scala
+++ b/src/reflect/scala/reflect/internal/Definitions.scala
@@ -1359,7 +1359,7 @@ trait Definitions extends api.StandardDefinitions {
       else boxedClass.map(kvp => (kvp._2: Symbol, kvp._1)).getOrElse(sym, NoSymbol)
 
     /** Is type's symbol a numeric value class? */
-    def isNumericValueType(tp: Type): Boolean = tp match {
+    def isNumericValueType(tp: Type): Boolean = tp.widen match {
       case TypeRef(_, sym, _) => isNumericValueClass(sym)
       case _                  => false
     }

--- a/src/reflect/scala/reflect/internal/SymbolTable.scala
+++ b/src/reflect/scala/reflect/internal/SymbolTable.scala
@@ -52,6 +52,7 @@ abstract class SymbolTable extends macros.Universe
   val gen = new InternalTreeGen { val global: SymbolTable.this.type = SymbolTable.this }
 
   def log(msg: => AnyRef): Unit
+  def sip23: Boolean = false // temporary, overriden in Global
 
   protected def elapsedMessage(msg: String, start: Long) =
     msg + " in " + (TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) - start) + "ms"

--- a/src/reflect/scala/reflect/internal/TreeGen.scala
+++ b/src/reflect/scala/reflect/internal/TreeGen.scala
@@ -77,6 +77,8 @@ abstract class TreeGen {
         else mkAttributedThis(clazz)
       case SingleType(pre, sym) =>
         mkApplyIfNeeded(mkAttributedStableRef(pre, sym))
+      case LiteralType(value) =>
+        Literal(value) setType tpe
       case TypeRef(pre, sym, args) =>
         if (sym.isRoot) {
           mkAttributedThis(sym)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2447,7 +2447,7 @@ trait Types
       if (isTrivial || phase.erasedTypes) resultType
       else if (/*isDependentMethodType &&*/ sameLength(actuals, params)) {
         val idm = new InstantiateDependentMap(params, actuals)
-        val res = idm(resultType)
+        val res = idm(resultType).deconst
         existentialAbstraction(idm.existentialsNeeded, res)
       }
       else existentialAbstraction(params, resultType)

--- a/src/reflect/scala/reflect/internal/Types.scala
+++ b/src/reflect/scala/reflect/internal/Types.scala
@@ -2799,6 +2799,8 @@ trait Types
       value
     }
 
+    def precludesWidening(tp: Type) = tp.isStable || tp.contains(SingletonClass)
+
     /** Create a new TypeConstraint based on the given symbol.
      */
     private def deriveConstraint(tparam: Symbol): TypeConstraint = {
@@ -2807,18 +2809,24 @@ trait Types
        *  See SI-5359.
        */
       val bounds  = tparam.info.bounds
+
       /* We can seed the type constraint with the type parameter
        * bounds as long as the types are concrete.  This should lower
        * the complexity of the search even if it doesn't improve
        * any results.
        */
-      if (propagateParameterBoundsToTypeVars) {
-        val exclude = bounds.isEmptyBounds || (bounds exists typeIsNonClassType)
+      val constr =
+        if (propagateParameterBoundsToTypeVars) {
+          val exclude = bounds.isEmptyBounds || (bounds exists typeIsNonClassType)
 
-        if (exclude) new TypeConstraint
-        else TypeVar.trace("constraint", "For " + tparam.fullLocationString)(new TypeConstraint(bounds))
-      }
-      else new TypeConstraint
+          if (exclude) new TypeConstraint
+          else TypeVar.trace("constraint", "For " + tparam.fullLocationString)(new TypeConstraint(bounds))
+        }
+        else new TypeConstraint
+
+      if (precludesWidening(bounds.hi)) constr.stopWidening()
+
+      constr
     }
     def untouchable(tparam: Symbol): TypeVar                 = createTypeVar(tparam, untouchable = true)
     def apply(tparam: Symbol): TypeVar                       = createTypeVar(tparam, untouchable = false)

--- a/src/reflect/scala/reflect/internal/Variances.scala
+++ b/src/reflect/scala/reflect/internal/Variances.scala
@@ -198,7 +198,8 @@ trait Variances {
     def inSym(sym: Symbol): Variance = if (sym.isAliasType) inType(sym.info).cut else inType(sym.info)
     def inType(tp: Type): Variance   = tp match {
       case ErrorType | WildcardType | NoType | NoPrefix => Bivariant
-      case ThisType(_) | ConstantType(_)                => Bivariant
+      case ThisType(_) | ConstantType(_)
+           | LiteralType(_)                             => Bivariant
       case TypeRef(_, `tparam`, _)                      => Covariant
       case BoundedWildcardType(bounds)                  => inType(bounds)
       case NullaryMethodType(restpe)                    => inType(restpe)

--- a/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
+++ b/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
@@ -131,6 +131,7 @@ object PickleFormat {
   final val NOPREFIXtpe = 12
   final val THIStpe = 13
   final val SINGLEtpe = 14
+  final val LITERALtpe = LITERAL // TODO SIP-23
   final val CONSTANTtpe = 15
   final val TYPEREFtpe = 16
   final val TYPEBOUNDStpe = 17

--- a/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
+++ b/src/reflect/scala/reflect/internal/pickling/PickleFormat.scala
@@ -131,7 +131,7 @@ object PickleFormat {
   final val NOPREFIXtpe = 12
   final val THIStpe = 13
   final val SINGLEtpe = 14
-  final val LITERALtpe = LITERAL // TODO SIP-23
+  final val LITERALtpe = LITERAL // SIP-23 -- LITERAL itself was not used as a picklerTag before this SIP (a NoTag Constant is not pickled)
   final val CONSTANTtpe = 15
   final val TYPEREFtpe = 16
   final val TYPEBOUNDStpe = 17

--- a/src/reflect/scala/reflect/internal/pickling/Translations.scala
+++ b/src/reflect/scala/reflect/internal/pickling/Translations.scala
@@ -66,6 +66,7 @@ trait Translations {
     case NoPrefix                      => NOPREFIXtpe
     case _: ThisType                   => THIStpe
     case _: SingleType                 => SINGLEtpe
+    case _: LiteralType                => LITERALtpe
     case _: SuperType                  => SUPERtpe
     case _: ConstantType               => CONSTANTtpe
     case _: TypeBounds                 => TYPEBOUNDStpe

--- a/src/reflect/scala/reflect/internal/pickling/Translations.scala
+++ b/src/reflect/scala/reflect/internal/pickling/Translations.scala
@@ -33,7 +33,7 @@ trait Translations {
   def picklerTag(ref: AnyRef): Int = ref match {
     case tp: Type                       => picklerTag(tp)
     case sym: Symbol                    => picklerTag(sym)
-    case const: Constant                => LITERAL + const.tag
+    case const: Constant                => if (sip23) assert (const.tag != NoTag) ; LITERAL + const.tag
     case _: Tree                        => TREE           // its sub tag more precisely identifies it
     case _: TermName                    => TERMname
     case _: TypeName                    => TYPEname

--- a/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
+++ b/src/reflect/scala/reflect/internal/pickling/UnPickler.scala
@@ -414,6 +414,7 @@ abstract class UnPickler {
         case SINGLEtpe                 => SingleType(readTypeRef(), readSymbolRef().filter(_.isStable)) // SI-7596 account for overloading
         case SUPERtpe                  => SuperType(readTypeRef(), readTypeRef())
         case CONSTANTtpe               => ConstantType(readConstantRef())
+        case LITERALtpe                => LiteralType(readConstantRef())
         case TYPEREFtpe                => TypeRef(readTypeRef(), readSymbolRef(), readTypes())
         case TYPEBOUNDStpe             => TypeBounds(readTypeRef(), readTypeRef())
         case REFINEDtpe | CLASSINFOtpe => CompoundType(readSymbolRef(), readTypes())

--- a/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
+++ b/src/reflect/scala/reflect/internal/tpe/GlbLubs.scala
@@ -257,10 +257,13 @@ private[internal] trait GlbLubs {
       lub(tps)
   )
 
+  // Need to widen result when using isNumericSubType to compare.
+  // isNumericSubType considers types after dealiasWiden, so should perform same transform on return.
+  // Example unit test: `numericLub(0, 1) == Int` (without the dealiasWiden one of the types would be returned as-is...)
   def numericLub(ts: List[Type]) =
     ts reduceLeft ((t1, t2) =>
-      if (isNumericSubType(t1, t2)) t2
-      else if (isNumericSubType(t2, t1)) t1
+      if (isNumericSubType(t1, t2)) t2.dealiasWiden
+      else if (isNumericSubType(t2, t1)) t1.dealiasWiden
       else IntTpe)
 
   private val _lubResults = new mutable.HashMap[(Depth, List[Type]), Type]

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -372,8 +372,8 @@ trait TypeComparers {
   private def isSubType2(tp1: Type, tp2: Type, depth: Depth): Boolean = {
     def retry(lhs: Type, rhs: Type) = ((lhs ne tp1) || (rhs ne tp2)) && isSubType(lhs, rhs, depth)
 
-    // TODO SIP-23: should this just be tp1.isInstanceOf[SingletonType] && tp2.isInstanceOf[SingletonType]
-    if (isSingleType(tp1) && isSingleType(tp2) || isConstantType(tp1) && isConstantType(tp2))
+    // TODO SIP-23
+    if (tp1.isInstanceOf[SingletonType] && tp2.isInstanceOf[SingletonType])
       return (tp1 =:= tp2) || isThisAndSuperSubtype(tp1, tp2) || retry(tp1.underlying, tp2)
 
     if (tp1.isHigherKinded || tp2.isHigherKinded)

--- a/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeComparers.scala
@@ -224,6 +224,7 @@ trait TypeComparers {
       case ExistentialType(qs1, res1) => tp2 match { case ExistentialType(qs2, res2) => equalTypeParamsAndResult(qs1, res1, qs2, res2)       ; case _ => false }
       case ThisType(sym1)             => tp2 match { case ThisType(sym2)             => sym1 == sym2                                         ; case _ => false }
       case ConstantType(c1)           => tp2 match { case ConstantType(c2)           => c1 == c2                                             ; case _ => false }
+      case LiteralType(c1)            => tp2 match { case LiteralType(c2)            => c1 == c2                                             ; case _ => false }
       case NullaryMethodType(res1)    => tp2 match { case NullaryMethodType(res2)    => res1 =:= res2                                        ; case _ => false }
       case TypeBounds(lo1, hi1)       => tp2 match { case TypeBounds(lo2, hi2)       => lo1 =:= lo2 && hi1 =:= hi2                           ; case _ => false }
       case _                          => false
@@ -371,6 +372,7 @@ trait TypeComparers {
   private def isSubType2(tp1: Type, tp2: Type, depth: Depth): Boolean = {
     def retry(lhs: Type, rhs: Type) = ((lhs ne tp1) || (rhs ne tp2)) && isSubType(lhs, rhs, depth)
 
+    // TODO SIP-23: should this just be tp1.isInstanceOf[SingletonType] && tp2.isInstanceOf[SingletonType]
     if (isSingleType(tp1) && isSingleType(tp2) || isConstantType(tp1) && isConstantType(tp2))
       return (tp1 =:= tp2) || isThisAndSuperSubtype(tp1, tp2) || retry(tp1.underlying, tp2)
 

--- a/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeConstraints.scala
@@ -93,6 +93,7 @@ private[internal] trait TypeConstraints {
     def loBounds: List[Type] = if (numlo == NoType) lobounds else numlo :: lobounds
     def hiBounds: List[Type] = if (numhi == NoType) hibounds else numhi :: hibounds
     def avoidWiden: Boolean = avoidWidening
+    def stopWidening(): Unit = avoidWidening = true
 
     def addLoBound(tp: Type, isNumericBound: Boolean = false) {
       // For some reason which is still a bit fuzzy, we must let Nothing through as
@@ -117,9 +118,9 @@ private[internal] trait TypeConstraints {
     }
 
     def checkWidening(tp: Type) {
-      if(tp.isStable) avoidWidening = true
+      if (TypeVar.precludesWidening(tp)) stopWidening()
       else tp match {
-        case HasTypeMember(_, _) => avoidWidening = true
+        case HasTypeMember(_, _) => stopWidening()
         case _ =>
       }
     }

--- a/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
+++ b/src/reflect/scala/reflect/internal/tpe/TypeMaps.scala
@@ -124,6 +124,7 @@ private[internal] trait TypeMaps {
           if (pre1 eq pre) tp
           else singleType(pre1, sym)
         }
+      case LiteralType(_) => tp
       case MethodType(params, result) =>
         val params1 = flipped(mapOver(params))
         val result1 = this(result)

--- a/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
+++ b/src/reflect/scala/reflect/runtime/JavaUniverseForce.scala
@@ -137,6 +137,7 @@ trait JavaUniverseForce { self: runtime.JavaUniverse  =>
     this.NoPrefix
     this.ThisType
     this.SingleType
+    this.LiteralType
     this.SuperType
     this.TypeBounds
     this.CompoundType

--- a/test/files/pos/sip23_numericLub.scala
+++ b/test/files/pos/sip23_numericLub.scala
@@ -1,0 +1,3 @@
+class C {
+  def foo(x: Boolean) = if (x) 1 else 0
+}

--- a/test/files/run/literal-type-varargs.flags
+++ b/test/files/run/literal-type-varargs.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/literal-type-varargs.scala
+++ b/test/files/run/literal-type-varargs.scala
@@ -1,0 +1,4 @@
+object Test extends App {
+   val x = List.apply[1](1)
+   assert(x == List(1))
+}

--- a/test/files/run/sip-23-implicit-resolution.flags
+++ b/test/files/run/sip-23-implicit-resolution.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/sip-23-implicit-resolution.scala
+++ b/test/files/run/sip-23-implicit-resolution.scala
@@ -1,0 +1,17 @@
+object Test extends App {
+  trait Assoc[K] { type V ; val v: V }
+
+  def mkAssoc[K, V0](k: K, v0: V0): Assoc[k.type] { type V = V0 } = new Assoc[k.type] {type V = V0 ; val v = v0}
+  def lookup[K](k: K)(implicit a: Assoc[k.type]): a.V = a.v
+
+  implicit def firstAssoc = mkAssoc(1, "Panda!")
+  implicit def secondAssoc = mkAssoc(2, "Kitty!")
+
+  implicit def ageAssoc = mkAssoc("Age", 3)
+  implicit def nmAssoc = mkAssoc("Name", "Jane")
+
+  assert(lookup(1) == "Panda!")
+  assert(lookup(2) == "Kitty!")
+  assert(lookup("Age") == 3)
+  assert(lookup("Name") == "Jane")
+}

--- a/test/files/run/sip-23-no-constant-folding.check
+++ b/test/files/run/sip-23-no-constant-folding.check
@@ -1,0 +1,2 @@
+got 42
+panda

--- a/test/files/run/sip-23-no-constant-folding.flags
+++ b/test/files/run/sip-23-no-constant-folding.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/sip-23-no-constant-folding.scala
+++ b/test/files/run/sip-23-no-constant-folding.scala
@@ -1,0 +1,15 @@
+object Test extends App {
+
+  def noisyId[A](x: A): x.type = {
+    println(s"got $x")
+    x
+  }
+
+  def testNoConstantFolding(): 23 = {
+    println("panda")
+    23
+  }
+
+  assert(noisyId(42) == 42)
+  assert(testNoConstantFolding == 23)
+}

--- a/test/files/run/sip-23-type-equality.flags
+++ b/test/files/run/sip-23-type-equality.flags
@@ -1,0 +1,1 @@
+-Xexperimental

--- a/test/files/run/sip-23-type-equality.scala
+++ b/test/files/run/sip-23-type-equality.scala
@@ -1,0 +1,8 @@
+object Test extends App {
+  val x = 1
+  val y: x.type = 1
+
+  implicitly[x.type =:= y.type]
+  implicitly[1 =:= y.type]
+  implicitly[1 =:= x.type]
+}


### PR DESCRIPTION
WIP PR to centralize discussion, accept improvements/tests/polish/docs/...

Everyone is welcome to look for the checkboxes/TODO items here and in the discussion below and take them on! If you're not sure where/how to start, just ask!
# Testing
- [ ] syntax (infix notation, backquotes, quasiquotes, string interpolation?,...)
- [ ] subtyping
- [ ] implicits
- [ ] dependent method types
- [ ] type inference: not inferred for signatures, inferred when <: Singleton
# Spec/docs
- [ ] include negated literal types in InfixType BNF (like prefixExpr)
- [ ] update syntax overview in spec
- [ ] spec the subtyping relationship between `ConstantType` / `LiteralType` and `scala.Singleton`.
- [ ] include SIP doc under spec/
# Type inference / type checking
- [x] When inferring signatures, treat literal types like singleton types (i.e., don't infer them -- widen instead)
- [x] treat singleton type bound on type param same as Singleton bound (stopWidening when bounds exists _.isStable)
- [x] include fix for https://issues.scala-lang.org/browse/SI-8564 (idm.deconst)
- [x] lub/glb
- [x] instanceOf checks: `x.isInstanceOf[3]` should expand to `x == 3`, and `x.asInstanceOf[3]` should be `if (x != 3) throw new ClassCastException(..)`
# Corner cases
- [ ] `val t: 1 = t`  (NOTE: t has value 0...)
# Design space
- [x] Support negative literals
- [ ] Support Symbol literals --> challenge: desugars into Symbol.apply("symbol")
- [ ] Support class literals? (probably not)
- [x] Model `()` as `LiteralType`? (I say 'no': () is not a syntactic literal, it's also too deeply ingrained to incorporate here)
# Feature interaction
- [ ] Predicate on language flag (can't do this in parser, though -- use -Xsip:23 instead?)
- [ ] Update quasiquotes 
- [ ] Inconsistent representation of parse trees in different contexts
- [ ] scalap 
