### PR TITLE
Handle WrappedArray the same way as ArrayOps for binary compatibility

### DIFF
--- a/bincompat-forward.whitelist.conf
+++ b/bincompat-forward.whitelist.conf
@@ -770,18 +770,6 @@ filter {
         problemName=DirectMissingMethodProblem
     },
     {
-        matchName="scala.collection.mutable.WrappedArray.sliceImpl"
-        problemName=DirectMissingMethodProblem
-    },
-    {
-        matchName="scala.collection.mutable.WrappedArray.emptyImpl"
-        problemName=DirectMissingMethodProblem
-    },
-    {
-        matchName="scala.collection.mutable.WrappedArray.slice"
-        problemName=IncompatibleResultTypeProblem
-    },
-    {
         matchName="scala.collection.mutable.WrappedArray#ofRef.sliceImpl"
         problemName=DirectMissingMethodProblem
     },
@@ -892,6 +880,50 @@ filter {
     {
         matchName="scala.collection.mutable.ArrayOps#ofBoolean.emptyImpl$extension"
         problemName=DirectMissingMethodProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofByte"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofBoolean"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofChar"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofDouble"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofShort"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofRef"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofUnit"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofInt"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArrayImpl"
+      problemName=MissingClassProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofLong"
+      problemName=MissingTypesProblem
+    },
+    {
+      matchName="scala.collection.mutable.WrappedArray$ofFloat"
+      problemName=MissingTypesProblem
     },
     {
         matchName="scala.collection.mutable.WrappedArray#ofFloat.sliceImpl"

--- a/src/library/scala/collection/mutable/WrappedArray.scala
+++ b/src/library/scala/collection/mutable/WrappedArray.scala
@@ -72,17 +72,6 @@ extends AbstractSeq[T]
     else
       super.toArray[U]
   }
-  override def slice(from: Int, until: Int): WrappedArray[T] = {
-    val start = if (from < 0) 0 else from
-    if (until <= start || start >= repr.length)
-      return emptyImpl
-    val end = if (until > length) length else until
-    sliceImpl(start, end)
-  }
-  //retain existing functionallity for existing implementations outside this file
-  protected def emptyImpl: WrappedArray[T] = newBuilder.result()
-  //retain existing functionallity for existing implementations outside this file
-  protected def sliceImpl(from: Int, until: Int): WrappedArray[T] = super.slice(from, until)
 
   override def stringPrefix = "WrappedArray"
 
@@ -93,7 +82,20 @@ extends AbstractSeq[T]
    */
   override protected[this] def newBuilder: Builder[T, WrappedArray[T]] =
     new WrappedArrayBuilder[T](elemTag)
+}
 
+private[mutable] abstract class WrappedArrayImpl[T] extends WrappedArray[T] {
+  override def slice(from: Int, until: Int): WrappedArray[T] = {
+    val start = if (from < 0) 0 else from
+    if (until <= start || start >= repr.length)
+      return emptyImpl
+    val end = if (until > length) length else until
+    sliceImpl(start, end)
+  }
+
+  protected def emptyImpl: WrappedArray[T]
+
+  protected def sliceImpl(from: Int, until: Int): WrappedArray[T]
 }
 
 /** A companion object used to create instances of `WrappedArray`.
@@ -143,7 +145,7 @@ object WrappedArray {
   private val emptyWrappedChar = new ofChar(new Array[Char](0))
   private val emptyWrappedBoolean = new ofBoolean(new Array[Boolean](0))
 
-  final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArray[T] with Serializable {
+  final class ofRef[T <: AnyRef](val array: Array[T]) extends WrappedArrayImpl[T] with Serializable {
     lazy val elemTag = ClassTag[T](arrayElementClass(array.getClass))
     def length: Int = array.length
     def apply(index: Int): T = array(index).asInstanceOf[T]
@@ -152,7 +154,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofRef[T](util.Arrays.copyOfRange[T](array, from, until))
   }
 
-  final class ofByte(val array: Array[Byte]) extends WrappedArray[Byte] with Serializable {
+  final class ofByte(val array: Array[Byte]) extends WrappedArrayImpl[Byte] with Serializable {
     def elemTag = ClassTag.Byte
     def length: Int = array.length
     def apply(index: Int): Byte = array(index)
@@ -161,7 +163,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofByte(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofShort(val array: Array[Short]) extends WrappedArray[Short] with Serializable {
+  final class ofShort(val array: Array[Short]) extends WrappedArrayImpl[Short] with Serializable {
     def elemTag = ClassTag.Short
     def length: Int = array.length
     def apply(index: Int): Short = array(index)
@@ -170,7 +172,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofShort(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofChar(val array: Array[Char]) extends WrappedArray[Char] with Serializable {
+  final class ofChar(val array: Array[Char]) extends WrappedArrayImpl[Char] with Serializable {
     def elemTag = ClassTag.Char
     def length: Int = array.length
     def apply(index: Int): Char = array(index)
@@ -179,7 +181,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofChar(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofInt(val array: Array[Int]) extends WrappedArray[Int] with Serializable {
+  final class ofInt(val array: Array[Int]) extends WrappedArrayImpl[Int] with Serializable {
     def elemTag = ClassTag.Int
     def length: Int = array.length
     def apply(index: Int): Int = array(index)
@@ -188,7 +190,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofInt(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofLong(val array: Array[Long]) extends WrappedArray[Long] with Serializable {
+  final class ofLong(val array: Array[Long]) extends WrappedArrayImpl[Long] with Serializable {
     def elemTag = ClassTag.Long
     def length: Int = array.length
     def apply(index: Int): Long = array(index)
@@ -197,7 +199,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofLong(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofFloat(val array: Array[Float]) extends WrappedArray[Float] with Serializable {
+  final class ofFloat(val array: Array[Float]) extends WrappedArrayImpl[Float] with Serializable {
     def elemTag = ClassTag.Float
     def length: Int = array.length
     def apply(index: Int): Float = array(index)
@@ -206,7 +208,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofFloat(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofDouble(val array: Array[Double]) extends WrappedArray[Double] with Serializable {
+  final class ofDouble(val array: Array[Double]) extends WrappedArrayImpl[Double] with Serializable {
     def elemTag = ClassTag.Double
     def length: Int = array.length
     def apply(index: Int): Double = array(index)
@@ -215,7 +217,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofDouble(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofBoolean(val array: Array[Boolean]) extends WrappedArray[Boolean] with Serializable {
+  final class ofBoolean(val array: Array[Boolean]) extends WrappedArrayImpl[Boolean] with Serializable {
     def elemTag = ClassTag.Boolean
     def length: Int = array.length
     def apply(index: Int): Boolean = array(index)
@@ -224,7 +226,7 @@ object WrappedArray {
     protected override def sliceImpl(from: Int, until: Int) = new ofBoolean(util.Arrays.copyOfRange(array, from, until))
   }
 
-  final class ofUnit(val array: Array[Unit]) extends WrappedArray[Unit] with Serializable {
+  final class ofUnit(val array: Array[Unit]) extends WrappedArrayImpl[Unit] with Serializable {
     def elemTag = ClassTag.Unit
     def length: Int = array.length
     def apply(index: Int): Unit = array(index)


### PR DESCRIPTION
We introduce a package-private superclass with the overridden
implementations. This is public at the bytecode level, so it needs
to be whitelisted.